### PR TITLE
Remove message logging to avoid data leaks

### DIFF
--- a/src/main/java/com/penguineering/hareairis/ai/AIChatService.java
+++ b/src/main/java/com/penguineering/hareairis/ai/AIChatService.java
@@ -48,8 +48,6 @@ public class AIChatService {
 
             String response = chatResponse.getResult().getOutput().getContent();
 
-            logger.info("Received response from OpenAI: {}", response);
-
             Long promptTokens = chatResponse.getMetadata().getUsage().getPromptTokens();
             Long generationTokens = chatResponse.getMetadata().getUsage().getGenerationTokens();
 

--- a/src/main/java/com/penguineering/hareairis/rmq/ChatRequestHandler.java
+++ b/src/main/java/com/penguineering/hareairis/rmq/ChatRequestHandler.java
@@ -71,7 +71,6 @@ public class ChatRequestHandler implements ChannelAwareMessageListener {
             logger.warn("Error_to header not provided, errors will be logged only!");
 
         try {
-            logger.info("Received message: {}", new String(message.getBody()));
             ChatRequest chatRequest = deserializeChatRequest(message);
 
             // Extract the "reply_to" property


### PR DESCRIPTION
This pull request includes changes to the logging functionality in the `AIChatService` and `ChatRequestHandler` classes. The most important changes involve the removal of specific logging statements.

Logging changes:

* [`src/main/java/com/penguineering/hareairis/ai/AIChatService.java`](diffhunk://#diff-98d90a3955fcb9c9d46e6868f2c03541c9ca8591855a79d303fae4d2569b5511L51-L52): Removed the logging statement that logs the response received from OpenAI.
* [`src/main/java/com/penguineering/hareairis/rmq/ChatRequestHandler.java`](diffhunk://#diff-f3757b1c4948b2bee82cdb9eecad8112adec058a59394534145d391cf150e69cL74): Removed the logging statement that logs the received message body.