### PR TITLE
Add simple rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Configuration is done using environment variables:
 * `RMQ_CHAT_REQUESTS`: RabbitMQ queue for chat requests (default `chat_requests`)
 * `OPENAI_API_KEY`: API key for accessing the OpenAI API
 * `OPENAI_ENDPOINT`: Base URL for the OpenAI API (default `https://api.openai.com/v1`)
+* `OPENAI_RATE_LIMIT`: The maximum number of requests allowed in a given period (default `50`)
+* `OPENAI_RATE_PERIOD_S`: The period in seconds for the rate limit to refresh (default `60`)
 
 ## Build
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,11 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-spring-boot2</artifactId>
+			<version>2.2.0</version>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>
@@ -144,6 +149,11 @@
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
+		</repository>
+		<repository>
+			<id>maven_central</id>
+			<name>Maven Central</name>
+			<url>https://repo.maven.apache.org/maven2/</url>
 		</repository>
 	</repositories>
 

--- a/src/main/java/com/penguineering/hareairis/ai/AIChatService.java
+++ b/src/main/java/com/penguineering/hareairis/ai/AIChatService.java
@@ -4,6 +4,7 @@ import com.azure.core.exception.HttpResponseException;
 import com.penguineering.hareairis.model.ChatException;
 import com.penguineering.hareairis.model.ChatRequest;
 import com.penguineering.hareairis.model.ChatResponse;
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.azure.openai.AzureOpenAiChatOptions;
@@ -32,7 +33,9 @@ public class AIChatService {
      * @param chatRequest The chat request to handle.
      * @return The chat response.
      */
+    @RateLimiter(name = "aiChatService")
     public ChatResponse handleChatRequest(ChatRequest chatRequest) {
+        logger.info("Calling AI Service");
         try {
             AzureOpenAiChatOptions options = renderAzureOpenAiChatOptions(chatRequest);
 

--- a/src/main/java/com/penguineering/hareairis/ai/AIChatServiceRateLimiterConfig.java
+++ b/src/main/java/com/penguineering/hareairis/ai/AIChatServiceRateLimiterConfig.java
@@ -1,0 +1,28 @@
+package com.penguineering.hareairis.ai;
+
+import io.github.resilience4j.common.ratelimiter.configuration.RateLimiterConfigCustomizer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+//@Configuration
+public class AIChatServiceRateLimiterConfig {
+
+    @Value("${OPENAI_RATE_LIMIT:50}")
+    private int limitForPeriod;
+
+    @Value("${OPENAI_RATE_PERIOD_S:60}")
+    private int refreshPeriod;
+
+
+    //  @Bean
+    public RateLimiterConfigCustomizer rateLimiterConfigCustomizer() {
+        return RateLimiterConfigCustomizer.of("aiChatService", builder ->
+                builder.limitForPeriod(limitForPeriod)
+                        .limitRefreshPeriod(Duration.ofSeconds(refreshPeriod))
+                        .timeoutDuration(Duration.ZERO)
+        );
+    }
+}

--- a/src/main/java/com/penguineering/hareairis/rmq/RabbitMQConfig.java
+++ b/src/main/java/com/penguineering/hareairis/rmq/RabbitMQConfig.java
@@ -30,6 +30,7 @@ public class RabbitMQConfig {
         container.setMessageListener(handler);
         container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
         container.setChannelTransacted(true);
+        container.setConcurrentConsumers(1);
         return container;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,13 @@ spring:
         initial-interval: 1000
         multiplier: 2
 
+resilience4j.ratelimiter:
+  instances:
+    aiChatService:
+      limitForPeriod: ${OPENAI_RATE_LIMIT:50}
+      limitRefreshPeriod: ${OPENAI_RATE_PERIOD_S:60}s
+      timeoutDuration: 0
+
 hareairis:
   rabbitmq:
     queue-chat-requests: ${RMQ_QUEUE_CHAT_REQUESTS:chat_requests}


### PR DESCRIPTION
Try to use resilience4j to add simple rate-limiting on serivce calls.

This has still some short-comings and since the OpenAI service gives backpressure information itself, it might be better to use that.

Leaving it as a draft PR for the time being.