### PR TITLE
Add API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,71 @@ rainbow and a messenger of the gods, symbolizing communication and connection. T
 agility, attributes often associated with rabbits. Together, "HareAIris" signifies a swift and efficient messenger that
 bridges the gap between RabbitMQ and OpenAI, embodying the project's core functionality.
 
+## API
+
+### Communication
+
+The service listens for `ChatRequest` JSON objects on the RabbitMQ queue configured by the `RMQ_CHAT_REQUESTS`
+environment variable, defaulting to `chat_requests`. The service will respond with a `ChatResponse` object or a
+`ChatError` object in case of an error.
+
+The response will be sent to the default exchange with the routing key defined in the `reply_to` *property* of the
+request. This property must be provided in the request.
+
+Errors will be sent to the default exchange with the routing key set in the `error_to` *header*. This header is optional,
+but omitting it will prevent the client from receiving error messages and result in a warning printed to the log.
+
+(Please note the difference between properties and headers in RabbitMQ.)
+
+If a `correlation_id` property is set in the request, it will be copied to the response.
+
+The service will acknowledge the message on success or client errors. In case of an internal error, the message
+will be re-queued.
+
+### ChatRequest
+
+The `ChatRequest` object represents a request to the OpenAI API. It includes the following fields:
+
+```json
+{
+  "system-message": "String",
+  "prompt": "String",
+  "max-tokens": "Integer",
+  "temperature": "Double",
+  "top-p": "Double",
+  "presence-penalty": "Double",
+  "frequency-penalty": "Double"
+}
+```
+
+### ChatResponse
+
+The `ChatResponse` object represents a response from the OpenAI API. It includes the following fields:
+
+```json
+{
+  "response": "String",
+  "input-tokens": "int",
+  "output-tokens": "int"
+}
+```
+
+### ChatError
+
+The `ChatError` object represents an error response from the OpenAI API. It includes the following fields:
+
+```json
+{
+  "code": "int",
+  "message": "String"
+}
+```
+
+### Monitoring
+
+The service provides a health check endpoint at HTTP `/actuators/health` that returns a `200 OK` status code if the
+service is running.
+
 ## Configuration
 
 Configuration is done using environment variables:

--- a/src/main/java/com/penguineering/hareairis/model/ChatError.java
+++ b/src/main/java/com/penguineering/hareairis/model/ChatError.java
@@ -6,17 +6,33 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * Represents a chat error.
+ *
+ * <p>Represents a chat error that can be sent back to the chat client.</p>
+ */
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ChatError {
+    /**
+     * The error code, matching an HTTP status code.
+     */
     @JsonProperty("code")
     private int code;
 
+    /**
+     * The error message.
+     */
     @JsonProperty("message")
     private String message;
 
+    /**
+     * Creates a new chat error from a chat exception.
+     *
+     * @param ex The chat exception.
+     */
     public ChatError(ChatException ex) {
         this.code = ex.getCode();
         this.message = ex.getMessage();

--- a/src/main/java/com/penguineering/hareairis/model/ChatRequest.java
+++ b/src/main/java/com/penguineering/hareairis/model/ChatRequest.java
@@ -6,16 +6,25 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.Optional;
-
+/**
+ * Represents a chat request.
+ *
+ * <p>Represents a chat request that can be sent to the AI service.</p>
+ */
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ChatRequest {
+    /**
+     * The system message of the chat client.
+     */
     @JsonProperty("system-message")
     private String systemMessage = "";
 
+    /**
+     * The actual prompt.
+     */
     @JsonProperty("prompt")
     private String prompt = "";
 

--- a/src/main/java/com/penguineering/hareairis/model/ChatResponse.java
+++ b/src/main/java/com/penguineering/hareairis/model/ChatResponse.java
@@ -4,18 +4,32 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
+/**
+ * Represents a chat response.
+ *
+ * <p>Represents a chat response that can be sent back to the chat client.</p>
+ */
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ChatResponse {
+    /**
+     * The response from the AI service.
+     */
     @JsonProperty("response")
     private String response;
 
+    /**
+     * The number of input tokens.
+     */
     @JsonProperty("input-tokens")
     private int inputTokens;
 
+    /**
+     * The number of output tokens.
+     */
     @JsonProperty("output-tokens")
     private int outputTokens;
 }


### PR DESCRIPTION
This pull request includes documentation updates and enhancements to the `ChatRequest`, `ChatResponse`, and `ChatError` models. The most important changes involve adding detailed API documentation to the `README.md` file and enhancing the Java model classes with comprehensive JavaDoc comments.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R11-R75): Added detailed API documentation, including sections for `ChatRequest`, `ChatResponse`, `ChatError`, and monitoring endpoints.

### Model Enhancements:

* [`src/main/java/com/penguineering/hareairis/model/ChatError.java`](diffhunk://#diff-7dffec7e110ab2ac5d7282d4b39a5f3209ebfc98159f64ec912a5810fc309640R9-R35): Added JavaDoc comments to describe the `ChatError` class and its fields.
* [`src/main/java/com/penguineering/hareairis/model/ChatRequest.java`](diffhunk://#diff-11f1e8d2f1e349f01099fc0166aefff7d85aac38d13fd8b8bb2db444759a5326L9-R27): Added JavaDoc comments to describe the `ChatRequest` class and its fields.
* [`src/main/java/com/penguineering/hareairis/model/ChatResponse.java`](diffhunk://#diff-90073370caa4cb4de72064e55dc519ce0622c0cd6dcc51386dc849f4dbc7b140R7-R32): Added JavaDoc comments to describe the `ChatResponse` class and its fields.